### PR TITLE
Fix #26 IE11 for loops and unsupported feature NavigatorLanguage.languages

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -20,7 +20,7 @@ export function isHeadless() {
         || ua.indexOf("crawl") !== -1 // Only IE5 has two distributions that has this on windows NT.. so yeah.
         || nav.webdriver === true
         || !nav.language
-        || !nav.languages.length
+        || (nav.languages !== undefined && !nav.languages.length) // IE 11 does not support NavigatorLanguage.languages https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages
         || !correctPrototypes
      );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,11 +6,14 @@ let autoWidget = fc ? fc.autoWidget : null;
 
 const elements = findCaptchaElements();
 
-for (let element of elements) {
-    const hElement = element as HTMLElement;
-    if (hElement && !hElement.dataset["attached"]) {
-        autoWidget = new WidgetInstance(hElement);
-        hElement.dataset["attached"] = "1";
+for (var index in elements) {
+    if (elements[index] !== undefined) {
+        const hElement = elements[index] as HTMLElement;
+
+        if (hElement && !hElement.dataset["attached"]) {
+            autoWidget = new WidgetInstance(hElement);
+            hElement.dataset["attached"] = "1";
+        }
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,14 +6,12 @@ let autoWidget = fc ? fc.autoWidget : null;
 
 const elements = findCaptchaElements();
 
-for (var index in elements) {
-    if (elements[index] !== undefined) {
-        const hElement = elements[index] as HTMLElement;
+for (var index = 0; index < elements.length; index++) {
+    const hElement = elements[index] as HTMLElement;
 
-        if (hElement && !hElement.dataset["attached"]) {
-            autoWidget = new WidgetInstance(hElement);
-            hElement.dataset["attached"] = "1";
-        }
+    if (hElement && !hElement.dataset["attached"]) {
+        autoWidget = new WidgetInstance(hElement);
+        hElement.dataset["attached"] = "1";
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/FriendlyCaptcha/friendly-challenge/issues/26

1. convert for of Loop into classic for Loop for IE11 compatibility
2. NavigatorLanguage.languages is not supported in IE11

Fixes the non-working issues expierenced in v0.8.1
Tested with Chrome 88, Firefox 86, Safari 14 and IE 11

IE11 performance is still very poor due to Web Assembly missing :-(