### PR TITLE
Localized, friendlier errors. Easier use in SSR frameworks (e.g. Gatsby)

### DIFF
--- a/docs/browser_support.md
+++ b/docs/browser_support.md
@@ -9,12 +9,12 @@ If you want to support browsers over 4 years old, you will need some polyfills (
 You can use the build that includes the polyfills:
 ```html
 <!-- from unpkg -->
-<script type="module" src="https://unpkg.com/friendly-challenge@0.8.5/widget.module.min.js" async defer></script>
-<script nomodule src="https://unpkg.com/friendly-challenge@0.8.5/widget.polyfilled.min.js" async defer></script>
+<script type="module" src="https://unpkg.com/friendly-challenge@0.8.6/widget.module.min.js" async defer></script>
+<script nomodule src="https://unpkg.com/friendly-challenge@0.8.6/widget.polyfilled.min.js" async defer></script>
 
 <!-- OR from jsdelivr -->
-<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.5/dist/widget.module.min.js" async defer></script>
-<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.5/dist/widget.polyfilled.min.js" async defer></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.6/dist/widget.module.min.js" async defer></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.6/dist/widget.polyfilled.min.js" async defer></script>
 ```
 
 Or you can include the polyfills manually:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.8.6
+* Improved the error message when a puzzle could not be fetched.
+  * The error is localized.
+  * The end-user is no longer presented with the JS error, instead it is printed in the console for debugging.
+  * In case of connection error a clickable link is added.
+  * The error message now spans two lines, the line height was slightly reduced.
+* Browser APIs used outside of functions are now guarded by a `typeof window !== 'undefined'`, this makes using FriendlyCaptcha easier in Gatsby and Next.js projects. Thank you @fdeberle!
+
 ## 0.8.5
 * Added check to make sure that the widget code gets executed after the DOM has been loaded. See #20.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
   * In case of connection error a clickable link is added.
   * The error message now spans two lines, the line height was slightly reduced.
 * Browser APIs used outside of functions are now guarded by a `typeof window !== 'undefined'`, this makes using FriendlyCaptcha easier in Gatsby and Next.js projects. Thank you @fdeberle!
+* A small change to the retry behavior (in case of network failure): it now retries twice: after 1 second and after 4 seconds. After that the user can click the button to try again.
 
 ## 0.8.5
 * Added check to make sure that the widget code gets executed after the DOM has been loaded. See #20.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,15 +26,15 @@ The **friendly-challenge** library contains the code for CAPTCHA widget. You hav
 
 ```html
 <!-- from unpkg -->
-<script type="module" src="https://unpkg.com/friendly-challenge@0.8.5/widget.module.min.js" async defer></script>
-<script nomodule src="https://unpkg.com/friendly-challenge@0.8.5/widget.min.js" async defer></script>
+<script type="module" src="https://unpkg.com/friendly-challenge@0.8.6/widget.module.min.js" async defer></script>
+<script nomodule src="https://unpkg.com/friendly-challenge@0.8.6/widget.min.js" async defer></script>
 
 <!-- OR from jsdelivr -->
-<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.5/widget.module.min.js" async defer></script>
-<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.5/widget.min.js" async defer></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.6/widget.module.min.js" async defer></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.6/widget.min.js" async defer></script>
 ```
 
-> Make sure to always import a specific version (e.g. `friendly-challenge@0.8.5`), then you can be sure that the script you import and integrate with your website doesn't change unexpectedly.
+> Make sure to always import a specific version (e.g. `friendly-challenge@0.8.6`), then you can be sure that the script you import and integrate with your website doesn't change unexpectedly.
 
 It is recommended that you include the `async` and `defer` attributes like in the examples above, they make sure that the browser does not wait to load these scripts to show your website. The size of the scripts is 18KB (8.5KB compressed) for modern browsers, and 24KB (10KB compressed) for old browsers.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,22 +91,21 @@ The response will tell you whether the CAPTCHA solution is valid and hasn't been
 ```JSON
 {
   "success": true|false,
-  "errorCodes": [...] // optional
+  "errors": [...] // optional
 }
 ```
 
-If `success` is false, `errorCodes` will be a list containing at least one of the following error codes below. **If you are seeing status code 400 or 401 your server code is probably not configured correctly.**
+If `success` is false, `errors` will be a list containing at least one of the following error codes below. **If you are seeing status code 400 or 401 your server code is probably not configured correctly.**
 
 
 | Error code   | Status |Description |
 |----------------|----------|-------------------------------------------|
-| `missing_secret`       | 400 | You forgot to add the secret (=API key) parameter. |
-| `invalid_secret`       | 401 | The API key you provided was invalid. |
-| `missing_solution` | 400 | You forgot to add the solution parameter. |
+| `secret_missing`       | 400 | You forgot to add the secret (=API key) parameter. |
+| `secret_invalid`       | 401 | The API key you provided was invalid. |
+| `solution_missing` | 400 | You forgot to add the solution parameter. |
 | `bad_request` | 400 | Something else is wrong with your request, e.g. your request body is empty. |
-| `invalid_solution` | 200 | The solution you provided was invalid (perhaps the user tried to tamper with the puzzle). |
-| `timeout_or_duplicate` | 200 | The puzzle that the solution was for has expired or has already been used. |
-
+| `solution_invalid` | 200 | The solution you provided was invalid (perhaps the user tried to tamper with the puzzle). |
+| `solution_timeout_or_duplicate` | 200 | The puzzle that the solution was for has expired or has already been used. |
 
 > ⚠️ Status code 200 does not mean the solution was valid, it just means the verification was performed succesfully. Use the `success` field.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ You can then import it into your app:
 import "friendly-challenge/widget";
 ```
 
-> It is also possible to create and interact with the widget using the Javascript API. In this tutorial we will consider the simple case in which you want to secure a simple HTML form. If you are making a single page application (using e.g. React) you will probably want to use the API instead. See the [API documentation page]("/api).
+> It is also possible to create and interact with the widget using the Javascript API. In this tutorial we will consider the simple case in which you want to secure a simple HTML form. If you are making a single page application (using e.g. React) you will probably want to use the API instead. See the [API documentation page]("/widget_api).
 
 ### Adding the widget itself
 

--- a/docs/verification_api.md
+++ b/docs/verification_api.md
@@ -19,21 +19,21 @@ The response will tell you whether the CAPTCHA solution is valid and hasn't been
 ```JSON
 {
   "success": true|false,
-  "errorCodes": [...] // optional
+  "errors": [...] // optional
 }
 ```
 
-If `success` is false, `errorCodes` will be a list containing at least one of the following error codes below. **If you are seeing status code 400 or 401 your server code is probably not configured correctly.**
+If `success` is false, `errors` will be a list containing at least one of the following error codes below. **If you are seeing status code 400 or 401 your server code is probably not configured correctly.**
 
 
 | Error code   | Status |Description |
 |----------------|----------|-------------------------------------------|
-| `missing_secret`       | 400 | You forgot to add the secret (=API key) parameter. |
-| `invalid_secret`       | 401 | The API key you provided was invalid. |
-| `missing_solution` | 400 | You forgot to add the solution parameter. |
+| `secret_missing`       | 400 | You forgot to add the secret (=API key) parameter. |
+| `secret_invalid`       | 401 | The API key you provided was invalid. |
+| `solution_missing` | 400 | You forgot to add the solution parameter. |
 | `bad_request` | 400 | Something else is wrong with your request, e.g. your request body is empty. |
-| `invalid_solution` | 200 | The solution you provided was invalid (perhaps the user tried to tamper with the puzzle). |
-| `timeout_or_duplicate` | 200 | The puzzle that the solution was for has expired or has already been used. |
+| `solution_invalid` | 200 | The solution you provided was invalid (perhaps the user tried to tamper with the puzzle). |
+| `solution_timeout_or_duplicate` | 200 | The puzzle that the solution was for has expired or has already been used. |
 
 
 > ⚠️ Status code 200 does not mean the solution was valid, it just means the verification was performed succesfully. Use the `success` field.

--- a/docs/widget_api.md
+++ b/docs/widget_api.md
@@ -94,6 +94,7 @@ function doneCallback(solution) {
     // ... Do something with the solution, maybe use it in a request
 }
 
+// This element should contain the `frc-captcha` class for correct styling
 const element = document.querySelector("#my-widget");
 const options = {
     doneCallback: doneCallback;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "friendly-challenge",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friendly-challenge",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "The client code used for FriendlyCaptcha (widget script, html, styling and webworker solver)",
   "keywords": [
     "captcha",

--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -151,7 +151,7 @@ export class WidgetInstance {
 
     private onWorkerError(e: any) {
         this.needsReInit = true;
-        this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "background worker error " + e.message);
+        this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "Background worker error " + e.message);
         this.makeButtonStart();
 
         // Just out of precaution

--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -9,7 +9,12 @@ import { Puzzle, decodeBase64Puzzle, getPuzzle } from './puzzle';
 import { Localization, localizations } from './localization';
 
 const PUZZLE_ENDPOINT_URL = "https://api.friendlycaptcha.com/api/v1/puzzle";
-const URL = window.URL || window.webkitURL;
+
+// Defensive init to make it easier to integrate with Gatsby and friends.
+let URL: any;
+if (typeof window !== 'undefined') {
+    URL = window.URL || window.webkitURL;
+}
 
 export interface WidgetInstanceOptions {
     forceJSFallback: boolean;
@@ -146,7 +151,7 @@ export class WidgetInstance {
 
     private onWorkerError(e: any) {
         this.needsReInit = true;
-        this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "Background worker error " + e.message);
+        this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "background worker error " + e.message);
         this.makeButtonStart();
 
         // Just out of precaution
@@ -202,12 +207,12 @@ export class WidgetInstance {
         const sitekey = this.opts.sitekey || this.e.dataset["sitekey"];
         if (!sitekey) {
             console.error("FriendlyCaptcha: sitekey not set on frc-captcha element");
-            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "Website problem: sitekey not set", false);
+            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "website problem: sitekey not set", false);
             return;
         }
 
         if (isHeadless()) {
-            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "Browser check failed, try a different browser", false);
+            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "browser check failed, try a different browser", false);
             return;
         }
 
@@ -219,10 +224,10 @@ export class WidgetInstance {
 
         try {
             this.e.innerHTML = getFetchingHTML(this.opts.solutionFieldName, this.lang);
-            this.puzzle = decodeBase64Puzzle(await getPuzzle(this.opts.puzzleEndpoint, sitekey));
+            this.puzzle = decodeBase64Puzzle(await getPuzzle(this.opts.puzzleEndpoint, sitekey, this.lang));
             setTimeout(() => this.expire(), this.puzzle.expiry - 30000); // 30s grace
         } catch(e) {
-            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, e.toString());
+            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, e.message);
             this.makeButtonStart();
             const code = "error_getting_puzzle";
 

--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -207,12 +207,12 @@ export class WidgetInstance {
         const sitekey = this.opts.sitekey || this.e.dataset["sitekey"];
         if (!sitekey) {
             console.error("FriendlyCaptcha: sitekey not set on frc-captcha element");
-            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "website problem: sitekey not set", false);
+            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "Website problem: sitekey not set", false);
             return;
         }
 
         if (isHeadless()) {
-            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "browser check failed, try a different browser", false);
+            this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "Browser check failed, try a different browser", false);
             return;
         }
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -94,7 +94,7 @@ export function getErrorHTML(fieldName: string, l: Localization, errorDescriptio
     return getTemplate(
         fieldName,
         errorSVG,
-        l.text_error + " " + errorDescription,
+        `<b>${l.text_error}</b><br>${errorDescription}`,
         ".ERROR",
         recoverable ? l.button_retry: undefined,
     )

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,5 +1,10 @@
-const nav = navigator;
-const ua = nav.userAgent.toLowerCase();
+// Defensive init to make it easier to integrate with Gatsby and friends.
+let nav: Navigator;
+let ua: string;
+if (typeof navigator !== "undefined") {
+  nav = navigator;
+  ua = nav.userAgent.toLowerCase();
+}
 
 /**
  * Headless browser detection on the clientside is imperfect. One can modify any clientside code to disable or change this check,
@@ -7,20 +12,24 @@ const ua = nav.userAgent.toLowerCase();
  * it stops unsophisticated scripters from making any request whatsoever.
  */
 export function isHeadless() {
-    let correctPrototypes = true;
-    try {
-        correctPrototypes = PluginArray.prototype === (nav.plugins as any).__proto__;
-        if (nav.plugins.length > 0) correctPrototypes = correctPrototypes &&  Plugin.prototype === (nav.plugins as any)[0].__proto__;
-    } catch(e){/* Do nothing, this browser misbehaves in mysterious ways */}
+  let correctPrototypes = true;
+  try {
+    correctPrototypes =
+      PluginArray.prototype === (nav.plugins as any).__proto__;
+    if (nav.plugins.length > 0) {
+      correctPrototypes = correctPrototypes &&
+        Plugin.prototype === (nav.plugins as any)[0].__proto__;
+    }
+  } catch (e) { /* Do nothing, this browser misbehaves in mysterious ways */ }
 
-    return ( //tell-tale bot signs
-        ua.indexOf("headless") !== -1
-        || nav.appVersion.indexOf("Headless") !== -1
-        || ua.indexOf("bot") !== -1 // http://www.useragentstring.com/pages/useragentstring.php?typ=Browser
-        || ua.indexOf("crawl") !== -1 // Only IE5 has two distributions that has this on windows NT.. so yeah.
-        || nav.webdriver === true
-        || !nav.language
-        || (nav.languages !== undefined && !nav.languages.length) // IE 11 does not support NavigatorLanguage.languages https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages
-        || !correctPrototypes
-     );
+  return ( //tell-tale bot signs
+    ua.indexOf("headless") !== -1 ||
+    nav.appVersion.indexOf("Headless") !== -1 ||
+    ua.indexOf("bot") !== -1 || // http://www.useragentstring.com/pages/useragentstring.php?typ=Browser
+    ua.indexOf("crawl") !== -1 || // Only IE5 has two distributions that has this on windows NT.. so yeah.
+    nav.webdriver === true ||
+    !nav.language ||
+    (nav.languages !== undefined && !nav.languages.length) || // IE 11 does not support NavigatorLanguage.languages https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages
+    !correctPrototypes
+  );
 }

--- a/src/html/custom-localization.html
+++ b/src/html/custom-localization.html
@@ -26,6 +26,7 @@
 
             text_error: "text_error",
             button_retry: "button_retry",
+            text_fetch_error: "text_fetch_error"
         }
         window.frc = new WidgetInstance(el, {language: myLanguage});
     </script>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -25,7 +25,7 @@
 
     <h3>Not allowed EU endpoint</h3>
     <div class="frc-captcha" data-sitekey="FCMGEMUD2KTDSQ5H" data-puzzle-endpoint="https://eu-api.friendlycaptcha.eu/api/v1/puzzle"></div>
-
+    <div class="frc-captcha" data-lang="de" data-sitekey="FCMGEMUD2KTDSQ5H" data-puzzle-endpoint="https://eu-api.friendlycaptcha.eu/api/v1/puzzle"></div>
 
     <hr>
     <form>

--- a/src/localization.ts
+++ b/src/localization.ts
@@ -22,8 +22,10 @@ export interface Localization {
     button_restart: string;
 
     // Error
-    text_error: string; // Should end with a colon (:), the error is shown after it.
+    text_error: string;
     button_retry: string;
+    // This error message is followed by the URL, a space is added. It is not the start of a sentence
+    text_fetch_error: string; 
 }
 
 // English
@@ -41,8 +43,9 @@ const LANG_EN: Localization = {
     text_expired: "Anti-Robot verification expired",
     button_restart: "Restart",
 
-    text_error: "Verification failed:",
+    text_error: "Verification failed",
     button_retry: "Retry",
+    text_fetch_error: "Failed to connect to",
 }
 
 // French
@@ -60,8 +63,9 @@ const LANG_FR: Localization = {
     text_expired: "Verification échue",
     button_restart: "Recommencer",
 
-    text_error: "Echec de verification:",
+    text_error: "Echec de verification",
     button_retry: "Recommencer",
+    text_fetch_error: "Problème de connexion avec", // TODO: verify by native speaker
 }
 
 // German
@@ -79,8 +83,9 @@ const LANG_DE: Localization = {
     text_expired: "Verifizierung abgelaufen",
     button_restart: "Erneut starten",
 
-    text_error: "Verifizierung fehlgeschlagen:",
+    text_error: "Verifizierung fehlgeschlagen",
     button_retry: "Erneut versuchen",   
+    text_fetch_error: "Verbindungsproblem mit", // TODO: verify by native speaker
 }
 
 // Dutch
@@ -98,8 +103,9 @@ const LANG_NL: Localization = {
     text_expired: "Verificatie verlopen",
     button_restart: "Opnieuw starten",
 
-    text_error: "Verificatie mislukt:",
-    button_retry: "Opnieuw proberen",   
+    text_error: "Verificatie mislukt",
+    button_retry: "Opnieuw proberen",
+    text_fetch_error: "Verbinding mislukt met"
 }
 
 // Italian
@@ -117,8 +123,9 @@ const LANG_IT: Localization = {
     text_expired: "Verifica Anti-Robot scaduta",
     button_restart: "Ricomincia",
 
-    text_error: "Verifica fallita:",
+    text_error: "Verifica fallita",
     button_retry: "Riprova",
+    text_fetch_error: "Problema di connessione con" // TODO: verify by native speaker
 }
 
 export const localizations = {

--- a/src/localization.ts
+++ b/src/localization.ts
@@ -24,7 +24,7 @@ export interface Localization {
     // Error
     text_error: string;
     button_retry: string;
-    // This error message is followed by the URL, a space is added. It is not the start of a sentence
+    // This error message is followed by the URL, a space is added.
     text_fetch_error: string; 
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,16 +15,15 @@ function setup() {
   let autoWidget = window.friendlyChallenge.autoWidget;
   
   const elements = findCaptchaElements();
-  for (var index = 0; index < elements.length; index++) {
+  for (let index = 0; index < elements.length; index++) {
       const hElement = elements[index] as HTMLElement;
       if (hElement && !hElement.dataset["attached"]) {
           autoWidget = new WidgetInstance(hElement);
           hElement.dataset["attached"] = "1";
       }
   }
-  
   window.friendlyChallenge.autoWidget = autoWidget;
-}
+};
 
 
 if(document.readyState !== "loading") {

--- a/src/puzzle.ts
+++ b/src/puzzle.ts
@@ -69,7 +69,7 @@ export async function getPuzzle(url: string, siteKey: string, lang: Localization
 export async function fetchAndRetryWithBackoff(url: RequestInfo, opts: RequestInit, n: number): Promise<Response> {
     let time = 500;
     return fetch(url, opts).catch(async (error) => {
-        if (n === 1) throw error;
+        if (n === 0) throw error;
         await new Promise(r => setTimeout(r, time));
         time *= 4;
         return fetchAndRetryWithBackoff(url, opts, n - 1);

--- a/src/puzzle.ts
+++ b/src/puzzle.ts
@@ -67,7 +67,7 @@ export async function getPuzzle(url: string, siteKey: string, lang: Localization
  * @param n Number of times to attempt before giving up.
  */
 export async function fetchAndRetryWithBackoff(url: RequestInfo, opts: RequestInit, n: number): Promise<Response> {
-    let time = 800;
+    let time = 1000;
     return fetch(url, opts).catch(async (error) => {
         if (n === 0) throw error;
         await new Promise(r => setTimeout(r, time));

--- a/src/puzzle.ts
+++ b/src/puzzle.ts
@@ -67,7 +67,7 @@ export async function getPuzzle(url: string, siteKey: string, lang: Localization
  * @param n Number of times to attempt before giving up.
  */
 export async function fetchAndRetryWithBackoff(url: RequestInfo, opts: RequestInit, n: number): Promise<Response> {
-    let time = 500;
+    let time = 800;
     return fetch(url, opts).catch(async (error) => {
         if (n === 0) throw error;
         await new Promise(r => setTimeout(r, time));

--- a/src/puzzle.ts
+++ b/src/puzzle.ts
@@ -61,7 +61,7 @@ export async function getPuzzle(url: string, siteKey: string, lang: Localization
 }
 
 /**
- * Retries given request with exponential backoff (starting with 500ms delay, multiplying by 4 every time)
+ * Retries given request with exponential backoff (starting with 1000ms delay, multiplying by 4 every time)
  * @param url Request (can be string url) to fetch
  * @param opts Options for fetch
  * @param n Number of times to attempt before giving up.

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,7 +8,7 @@
     transition: none !important;
     font-weight: normal;
     font-size: 14px;
-    line-height: 1.35;
+    line-height: 1.2;
     text-decoration: none;
     background-color: initial;
     color: #222;
@@ -21,6 +21,11 @@
     padding-bottom: 12px;
     background-color: #fff;
 }
+
+.frc-captcha b {
+    font-weight: bold;
+}
+
 
 .frc-container {
     display: flex;
@@ -58,10 +63,6 @@
 .frc-banner * {
     font-size: 10px;
     opacity: 0.8;
-}
-
-.frc-banner b {
-    font-weight: bold;
 }
 
 .frc-progress {


### PR DESCRIPTION
This PR contains the changes for version 0.8.6, before merging and publishing it I would love to receive thumbs-up that this resolves #25.

The error message now spans two lines, with a clickable link in case of a fetch error. Errors are printed in the console to allow for debugging - they are not shown to the end user. There are still some errors that are not localized, I'm not sure if they are worth chasing (i.e. errors with a wrong sitekey, these should be easy to resolve before shipping your website to end users).

### Screenshot
<img width="465" alt="Widget connection failure screenshot" src="https://user-images.githubusercontent.com/1039510/117163494-9b3eb600-adbb-11eb-929a-2a143341b819.png">
<img width="571" alt="Screenshot 2021-05-05 at 16 07 25" src="https://user-images.githubusercontent.com/1039510/117163938-0a1c0f00-adbc-11eb-9ad8-c0ec28ebf8fd.png">

### Other changes
* Improvement to compatibility with SSR (thank you @fdeberle)
* Minor improvements to retry behavior in case of complete connection failure.
