### PR TITLE
Fix name of output file generated

### DIFF
--- a/rollup.library.config.ts
+++ b/rollup.library.config.ts
@@ -68,7 +68,7 @@ export default [
  },
 {
   input: `src/index.ts`,
-  output: [{file: "dist/friendly-captcha.d.ts", format: "es"}],
+  output: [{file: "dist/friendly-challenge.d.ts", format: "es"}],
   plugins: [dts()],
 }
 ];


### PR DESCRIPTION
This PR fixes current typescript issue, where package.json have `types` property set to `friendly-challenge.d.ts` but rollup config outputs `friendly-captcha.d.ts`. This should be fixed in order for consumers of modules to not have broken TS.
