### PR TITLE
implement multiple workers for captcha solving

### DIFF
--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -1,5 +1,4 @@
-import { base64 } from "friendly-pow/wasm/optimized.wrap";
-import { decode, encode } from "friendly-pow/base64";
+import { encode } from "friendly-pow/base64";
 import {
   getRunningHTML,
   getReadyHTML,
@@ -12,12 +11,11 @@ import {
   injectStyle,
   getExpiredHTML,
 } from "./dom";
-// @ts-ignore
-import workerString from "../dist/worker.min.js";
 import { isHeadless } from "./headless";
-import { DoneMessage, ProgressMessage } from "./types";
+import { DoneMessage } from "./types";
 import { Puzzle, decodeBase64Puzzle, getPuzzle } from "./puzzle";
 import { Localization, localizations } from "./localization";
+import { WorkerGroup } from "./workergroup";
 
 const PUZZLE_ENDPOINT_URL = "https://api.friendlycaptcha.com/api/v1/puzzle";
 
@@ -43,8 +41,10 @@ export interface WidgetInstanceOptions {
 }
 
 export class WidgetInstance {
-  private worker: Worker | null = null;
+  private workers: Worker[] | null = null;
   private puzzle?: Puzzle;
+
+  private workerGroup: WorkerGroup = new WorkerGroup();
 
   /**
    * The root element of this widget instance.
@@ -115,8 +115,7 @@ export class WidgetInstance {
       console.error("FriendlyCaptcha widget has been destroyed using destroy(), it can not be used anymore.");
       return;
     }
-    this.initWorker();
-    this.setupSolver();
+    this.initWorkerGroup();
 
     if (forceStart) {
       this.start();
@@ -134,26 +133,6 @@ export class WidgetInstance {
       } else {
         console.log("FriendlyCaptcha div seems not to be contained in a form, autostart will not work");
       }
-    }
-  }
-
-  /**
-   * Compile the WASM and send the compiled module to the webworker.
-   * If WASM support is not present, it tells the webworker to initialize the JS solver instead.
-   */
-  private async setupSolver() {
-    if (this.opts.forceJSFallback) {
-      this.worker!.postMessage({ type: "js" });
-      return;
-    }
-    try {
-      const module = WebAssembly.compile(decode(base64));
-      this.worker!.postMessage({ type: "module", module: await module });
-    } catch (e) {
-      console.log(
-        "FriendlyCaptcha failed to initialize WebAssembly, falling back to Javascript solver: " + e.toString()
-      );
-      this.worker!.postMessage({ type: "js" });
     }
   }
 
@@ -177,38 +156,33 @@ export class WidgetInstance {
     this.opts.forceJSFallback = true;
   }
 
-  private initWorker() {
-    if (this.worker) this.worker.terminate();
-
-    const workerBlob = new Blob([workerString] as any, { type: "text/javascript" });
-    this.worker = new Worker(URL.createObjectURL(workerBlob));
-    this.worker.onerror = (e: ErrorEvent) => this.onWorkerError(e);
-
-    this.worker.onmessage = (e: any) => {
-      if (this.hasBeenDestroyed) return;
-
-      const data = e.data;
-      if (!data) return;
-      if (data.type === "progress") {
-        updateProgressBar(this.e, data as ProgressMessage);
-      } else if (data.type === "ready") {
-        this.e.innerHTML = getReadyHTML(this.opts.solutionFieldName, this.lang);
-        this.makeButtonStart();
-        this.opts.readyCallback();
-      } else if (data.type === "started") {
-        this.e.innerHTML = getRunningHTML(this.opts.solutionFieldName, this.lang);
-        this.opts.startedCallback();
-      } else if (data.type === "done") {
-        const solutionPayload = this.handleDone(data);
-        this.opts.doneCallback(solutionPayload);
-        const callback = this.e.dataset["callback"];
-        if (callback) {
-          (window as any)[callback](solutionPayload);
-        }
-      } else if (data.type === "error") {
-        this.onWorkerError(data);
-      }
+  private initWorkerGroup() {
+    this.workerGroup.progressCallback = (progress) => {
+      updateProgressBar(this.e, progress);
     };
+    this.workerGroup.readyCallback = () => {
+      this.e.innerHTML = getReadyHTML(this.opts.solutionFieldName, this.lang);
+      this.makeButtonStart();
+      this.opts.readyCallback();
+    };
+    this.workerGroup.startedCallback = () => {
+      this.e.innerHTML = getRunningHTML(this.opts.solutionFieldName, this.lang);
+      this.opts.startedCallback();
+    }
+    this.workerGroup.doneCallback = (data) => {
+      const solutionPayload = this.handleDone(data);
+      this.opts.doneCallback(solutionPayload);
+      const callback = this.e.dataset["callback"];
+      if (callback) {
+        (window as any)[callback](solutionPayload);
+      }
+    }
+    this.workerGroup.errorCallback = (e) => {
+      this.onWorkerError(e);
+    }
+
+    this.workerGroup.init();
+    this.workerGroup.setupSolver(this.opts.forceJSFallback);
   }
 
   private expire() {
@@ -267,12 +241,8 @@ export class WidgetInstance {
       }
       return;
     }
-    this.worker!.postMessage({
-      type: "start",
-      buffer: this.puzzle!.buffer,
-      n: this.puzzle!.n,
-      threshold: this.puzzle!.threshold,
-    });
+
+    this.workerGroup.start(this.puzzle!);
   }
 
   /**
@@ -286,7 +256,6 @@ export class WidgetInstance {
       data.diagnostics
     )}`;
     this.e.innerHTML = getDoneHTML(this.opts.solutionFieldName, this.lang, puzzleSolutionMessage, data);
-    if (this.worker) this.worker.terminate();
     // this.worker = null; // This literally crashes very old browsers..
     this.needsReInit = true;
 
@@ -298,8 +267,7 @@ export class WidgetInstance {
    * After it is destroyed it can no longer be used for any purpose.
    */
   public destroy() {
-    if (this.worker) this.worker.terminate();
-    this.worker = null;
+    this.workerGroup.terminateWorkers();
     this.needsReInit = false;
     this.hasBeenStarted = false;
     if (this.e) {
@@ -319,8 +287,7 @@ export class WidgetInstance {
       return;
     }
 
-    if (this.worker) this.worker.terminate();
-    this.worker = null;
+    this.workerGroup.terminateWorkers();
     this.needsReInit = false;
     this.hasBeenStarted = false;
     this.init(this.opts.startMode === "auto" || this.e.dataset["start"] === "auto");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,35 +1,37 @@
 export type Solver = (puzzleBuffer: Uint8Array, threshold: number, n?: number) => Uint8Array[];
 
-export type InitMessage = WasmInitMessage | JSInitMessage;
-
-export interface WasmInitMessage {
-  type: "module";
-  module: WebAssembly.Module;
-}
-
-export interface JSInitMessage {
-  type: "js";
-  module: WebAssembly.Module;
+export interface ReadyMessage {
+  type: "ready",
+  solver: 1|2
 }
 
 export interface StartMessage {
   type: "start";
-  buffer: Uint8Array;
+  puzzleSolverInputs: Uint8Array[];
   threshold: number;
   /**
    * Number of puzzles to be solved.
    */
   n: number;
+  numWorkers: number;
+  startIndex: number;
+}
+
+export interface ProgressPartMessage {
+  type: "progress";
+  /**
+   * Number of hashes it took to find this solution
+   */
+  h: number;
 }
 
 export interface ProgressMessage {
-  type: "progress";
   /**
    * Number of solutions to be found in total
    */
   n: number;
   /**
-   * Number of hashes it took to find this solution
+   * Number of all hashes calculated
    */
   h: number;
   /**
@@ -42,8 +44,13 @@ export interface ProgressMessage {
   i: number;
 }
 
-export interface DoneMessage {
+export interface DonePartMessage {
   type: "done";
+  solution: Uint8Array;
+  startIndex: number;
+}
+
+export interface DoneMessage {
   solution: Uint8Array;
   /**
    * Total number of hashes that were required

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,9 +1,9 @@
-import { getPuzzleSolverInputs } from "friendly-pow/puzzle";
+import { decode } from "friendly-pow/base64";
+import { base64 } from "friendly-pow/wasm/optimized.wrap";
 import { getWasmSolver } from "friendly-pow/api/wasm";
 import { getJSSolver } from "friendly-pow/api/js";
-import { createDiagnosticsBuffer } from "friendly-pow/diagnostics";
 import { SOLVER_TYPE_JS, SOLVER_TYPE_WASM } from "friendly-pow/constants";
-import { Solver, StartMessage, DoneMessage, ProgressMessage } from "./types";
+import { Solver, StartMessage, DonePartMessage, ProgressPartMessage } from "./types";
 
 if (!Uint8Array.prototype.slice) {
   Object.defineProperty(Uint8Array.prototype, "slice", {
@@ -38,22 +38,35 @@ self.onmessage = async (evt: any) => {
   const data = evt.data;
   const type = data.type;
   try {
-    if (type === "module") {
-      const s = await getWasmSolver(data.module);
+
+    /**
+     * Compile the WASM and setup the solver.
+     * If WASM support is not present, it uses the JS version instead.
+     */
+    if (type === "solver") {
+      if (data.forceJS) {
+        solverType = SOLVER_TYPE_JS;
+        const s = await getJSSolver();
+        setSolver(s);
+      } else {
+        try {
+          solverType = SOLVER_TYPE_WASM;
+          const module = WebAssembly.compile(decode(base64));
+          const s = await getWasmSolver(await module);
+          setSolver(s);
+        } catch (e) {
+          console.log(
+            "FriendlyCaptcha failed to initialize WebAssembly, falling back to Javascript solver: " + e.toString()
+          );
+          solverType = SOLVER_TYPE_JS;
+          const s = await getJSSolver();
+          setSolver(s);
+        }
+      }
       self.postMessage({
         type: "ready",
-        solver: SOLVER_TYPE_WASM,
+        solver: solverType,
       });
-      solverType = SOLVER_TYPE_WASM;
-      setSolver(s);
-    } else if (type === `js`) {
-      const s = await getJSSolver();
-      self.postMessage({
-        type: "ready",
-        solver: SOLVER_TYPE_JS,
-      });
-      solverType = SOLVER_TYPE_JS;
-      setSolver(s);
     } else if (type === "start") {
       if (hasStarted) {
         return;
@@ -64,13 +77,11 @@ self.onmessage = async (evt: any) => {
       self.postMessage({
         type: "started",
       });
-      let solverStartTime = Date.now();
       let totalH = 0;
-      const starts = getPuzzleSolverInputs((data as StartMessage).buffer, (data as StartMessage).n);
+      const starts = (data as StartMessage).puzzleSolverInputs;
       const solutionBuffer = new Uint8Array(8 * (data as StartMessage).n);
       // Note: var instead of const for IE11 compat
-      for (var i = 0; i < starts.length; i++) {
-        const startTime = Date.now();
+      for (var i = (data as StartMessage).startIndex; i < starts.length; i+=(data as StartMessage).numWorkers) {
         let solution!: Uint8Array;
         for (var b = 0; b < 256; b++) {
           // In the very unlikely case no solution is found we should try again
@@ -88,26 +99,18 @@ self.onmessage = async (evt: any) => {
         }
         const view = new DataView(solution.slice(-4).buffer);
         const h = view.getUint32(0, true);
-        const t = (Date.now() - startTime) / 1000;
         totalH += h;
 
         solutionBuffer.set(solution.slice(-8), i * 8); // The last 8 bytes are the solution nonce
         self.postMessage({
           type: "progress",
-          n: data.n,
-          h: h,
-          t: t,
-          i: i,
-        } as ProgressMessage);
+          h: h
+        } as ProgressPartMessage);
       }
-      const totalTime = (Date.now() - solverStartTime) / 1000;
-      const doneMessage: DoneMessage = {
+      const doneMessage: DonePartMessage = {
         type: "done",
         solution: solutionBuffer,
-        h: totalH,
-        t: totalTime,
-        diagnostics: createDiagnosticsBuffer(solverType, totalTime),
-        solver: solverType,
+        startIndex: (data as StartMessage).startIndex,
       };
 
       self.postMessage(doneMessage);

--- a/src/workergroup.ts
+++ b/src/workergroup.ts
@@ -1,0 +1,135 @@
+import { Puzzle } from "./puzzle";
+import { getPuzzleSolverInputs } from "friendly-pow/puzzle";
+import { createDiagnosticsBuffer } from "friendly-pow/diagnostics";
+import { ReadyMessage, DoneMessage, DonePartMessage, ProgressMessage, ProgressPartMessage } from "./types";
+// @ts-ignore
+import workerString from "../dist/worker.min.js";
+
+export class WorkerGroup {
+
+  private workers: Worker[] = [];
+  private numPuzzles: number = 0;
+  private startTime: number = 0;
+  private progress: number = 0;
+  private totalHashes: number = 0;
+  private puzzleSolverInputs: Uint8Array[] = [];
+  private solutionBuffer: Uint8Array = new Uint8Array(0);
+  // initialize some value, so ts is happy
+  private solverType: 1 | 2 = 1;
+
+  private readyCount: number = 0;
+  private startCount: number = 0;
+  private doneCount: number = 0;
+
+  public progressCallback: (p:ProgressMessage) => any = () => {};
+  public readyCallback: () => any = () => {};
+  public startedCallback: () => any = () => {};
+  public doneCallback: (d:DoneMessage) => any = () => {};
+  public errorCallback: (e:any) => any = () => {};
+
+  public init() {
+    if (this.workers.length > 0) {
+      for (var i=0; i < this.workers.length; i++) {
+        this.workers[i].terminate();
+      }
+    }
+
+    this.progress = 0;
+    this.totalHashes = 0;
+    
+    this.readyCount = 0;
+    this.startCount = 0;
+    this.doneCount = 0;
+
+    // Setup four workers for now - later we could calculate this depending on the device
+    this.workers = new Array(4);
+    const workerBlob = new Blob([workerString] as any, { type: "text/javascript" });
+
+    for (var i=0; i<4; i++) {
+      this.workers[i] = new Worker(URL.createObjectURL(workerBlob));
+      this.workers[i].onerror = (e: ErrorEvent) => this.errorCallback(e);
+
+      this.workers[i].onmessage = (e: any) => {
+        const data = e.data;
+        if (!data) return;
+        if (data.type === "progress") {
+          this.progress++;
+          this.totalHashes += (data as ProgressPartMessage).h;
+          this.progressCallback({
+            n: this.numPuzzles,
+            h: this.totalHashes,
+            t: (Date.now() - this.startTime) / 1000,
+            i: this.progress,
+          });
+        } else if (data.type === "ready") {
+          console.log("ready");
+          this.readyCount++;
+          this.solverType = (data as ReadyMessage).solver;
+          // We are ready, when all workers are ready
+          if (this.readyCount == this.workers.length) {
+            this.readyCallback();
+          }
+        } else if (data.type === "started") {
+          this.startCount++;
+          // We started, when the first worker starts working
+          if (this.startCount == 1) {
+            this.startTime = Date.now();
+            this.startedCallback();
+          }
+        } else if (data.type === "done") {
+          this.doneCount++;
+          console.log("Solution Buffer length: ", this.solutionBuffer.length);
+          for (var i=(data as DonePartMessage).startIndex; i<this.puzzleSolverInputs.length; i+=this.workers.length) {
+            console.log("Range: from ", i*8, " to ", i*8+8);
+            this.solutionBuffer.set((data as DonePartMessage).solution.subarray(i*8, i*8+8), i*8);
+          }
+          // We are done, when all workers are done
+          if (this.doneCount == this.workers.length) {
+            let totalTime = (Date.now() - this.startTime) / 1000;
+            this.doneCallback({
+              solution: this.solutionBuffer,
+              h: this.totalHashes,
+              t: totalTime,
+              diagnostics: createDiagnosticsBuffer(this.solverType, totalTime),
+              solver: this.solverType
+            });
+          }
+        } else if (data.type === "error") {
+          this.errorCallback(data);
+        }
+      }
+    }
+  }
+
+  public setupSolver(forceJS = false) {
+    for (var i=0; i<this.workers.length; i++) {
+      this.workers[i].postMessage({ type: "solver", data: {forceJS: forceJS} });
+    }
+  }
+
+  public start(puzzle: Puzzle) {
+    this.puzzleSolverInputs = getPuzzleSolverInputs(puzzle.buffer, puzzle.n);
+    this.solutionBuffer = new Uint8Array(8 * puzzle.n);
+    this.numPuzzles = puzzle.n;
+
+    for (var i=0; i<this.workers.length; i++) {
+      this.workers[i].postMessage({
+        type: "start",
+        puzzleSolverInputs: this.puzzleSolverInputs,
+        threshold: puzzle.threshold,
+        n: puzzle.n,
+        numWorkers: this.workers.length,
+        startIndex: i,
+      });
+    }
+  }
+
+  public terminateWorkers() {
+    if (this.workers.length == 0) return;
+    for (var i=0; i<this.workers.length; i++) {
+      this.workers[i].terminate();
+    }
+    this.workers = [];
+  }
+
+}


### PR DESCRIPTION
Currently the widget only creates a single webworker, even though more resources (i.e. CPU cores) are most likely available.

This commit creates multiple (currently exactly 4) webworkers to solve a problem.

### Why does this help beat spam?

Right now if a puzzle takes 10 seconds to complete, and a spammer has a 4 core machine they could pretty much open 4 tabs at a time and solve the puzzles in parallel. A real user will have to wait the full 10 seconds though. If we would solve 4 (sub)-puzzles in parallel in our widget the real user would be done faster, while the spammer will be able to spam just as much.

This would warrant an increase in base difficulty, making spamming (especially at scale) more costly, while the user may not notice much.

It may also bridge the gap a tiny bit w.r.t. PC vs mobile users, as mobile devices nowadays often have many, but weaker cores.