### PR TITLE
Improve balancing the work between web workers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface StartMessage {
   puzzleSolverInput: Uint8Array;
   threshold: number;
   puzzleIndex: number;
+  puzzleNumber: number;
 }
 
 export interface SolverMessage {
@@ -52,6 +53,7 @@ export interface DonePartMessage {
   type: "done";
   solution: Uint8Array;
   puzzleIndex: number;
+  puzzleNumber: number;
   /**
    * Hashes attempted for this solution
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ export interface StartMessage {
   type: "start";
   puzzleSolverInput: Uint8Array;
   threshold: number;
-  puzzleIndex: number;
 }
 
 export interface SolverMessage {
@@ -51,7 +50,7 @@ export interface ProgressMessage {
 export interface DonePartMessage {
   type: "done";
   solution: Uint8Array;
-  puzzleIndex: number;
+  puzzleSolverInput: Uint8Array;
   /**
    * Hashes attempted for this solution
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface StartMessage {
   type: "start";
   puzzleSolverInput: Uint8Array;
   threshold: number;
-  puzIndex: number;
+  puzzleIndex: number;
 }
 
 export interface SolverMessage {
@@ -51,7 +51,7 @@ export interface ProgressMessage {
 export interface DonePartMessage {
   type: "done";
   solution: Uint8Array;
-  puzIndex: number;
+  puzzleIndex: number;
   /**
    * Hashes attempted for this solution
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface StartMessage {
   type: "start";
   puzzleSolverInput: Uint8Array;
   threshold: number;
+  puzzleIndex: number;
 }
 
 export interface SolverMessage {
@@ -50,7 +51,7 @@ export interface ProgressMessage {
 export interface DonePartMessage {
   type: "done";
   solution: Uint8Array;
-  puzzleSolverInput: Uint8Array;
+  puzzleIndex: number;
   /**
    * Hashes attempted for this solution
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,13 @@
 export type Solver = (puzzleBuffer: Uint8Array, threshold: number, n?: number) => Uint8Array[];
 
-export type MessageFromWorker = ReadyMessage | StartedMessage | ProgressPartMessage | DonePartMessage | ErrorMessage;
+export type MessageFromWorker = ReadyMessage | StartedMessage | DonePartMessage | ErrorMessage;
 export type MessageToWorker = StartMessage | SolverMessage;
 
 export interface StartMessage {
   type: "start";
-  puzzleSolverInputs: Uint8Array[];
+  puzzleSolverInput: Uint8Array;
   threshold: number;
-  /**
-   * Number of puzzles to be solved.
-   */
-  n: number;
-  numWorkers: number;
-  startIndex: number;
+  puzIndex: number;
 }
 
 export interface SolverMessage {
@@ -32,14 +27,6 @@ export interface StartedMessage {
 export interface ErrorMessage {
   type: "error";
   message: string;
-}
-
-export interface ProgressPartMessage {
-  type: "progress";
-  /**
-   * Number of hashes it took to find this solution
-   */
-  h: number;
 }
 
 export interface ProgressMessage {
@@ -64,11 +51,11 @@ export interface ProgressMessage {
 export interface DonePartMessage {
   type: "done";
   solution: Uint8Array;
-  startIndex: number;
+  puzIndex: number;
   /**
    * Hashes attempted for this solution
    */
-  totalH: number;
+  h: number;
 }
 
 export interface DoneMessage {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -98,7 +98,7 @@ self.onmessage = async (evt: any) => {
         type: "done",
         solution: solution.slice(-8), // The last 8 bytes are the solution nonce
         h: totalH,
-        puzIndex: data.puzIndex,
+        puzzleIndex: data.puzzleIndex,
       } as DonePartMessage);
     }
   } catch (e) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -75,13 +75,11 @@ self.onmessage = async (evt: any) => {
       let totalH = 0;
       let solution!: Uint8Array;
 
-      const input = new Uint8Array(data.puzzleSolverInput);
-
       // We loop over a uint32 to find as solution, it is technically possible (but extremely unlikely - only possible with very high difficulty) that
       // there is no solution, here we loop over one byte further up too in case that happens.
       for (let b = 0; b < 256; b++) {
-        input[123] = b;
-        const [s, hash] = solve(input, data.threshold);
+        data.puzzleSolverInput[123] = b;
+        const [s, hash] = solve(data.puzzleSolverInput, data.threshold);
         if (hash.length === 0) {
           // This means 2^32 puzzles were evaluated, which takes a while in a browser!
           // As we try 256 times, this is not fatal
@@ -98,9 +96,9 @@ self.onmessage = async (evt: any) => {
 
       self.postMessage({
         type: "done",
-        puzzleSolverInput: data.puzzleSolverInput,
         solution: solution.slice(-8), // The last 8 bytes are the solution nonce
         h: totalH,
+        puzzleIndex: data.puzzleIndex,
       } as DonePartMessage);
     }
   } catch (e) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -75,11 +75,13 @@ self.onmessage = async (evt: any) => {
       let totalH = 0;
       let solution!: Uint8Array;
 
+      const input = new Uint8Array(data.puzzleSolverInput);
+
       // We loop over a uint32 to find as solution, it is technically possible (but extremely unlikely - only possible with very high difficulty) that
       // there is no solution, here we loop over one byte further up too in case that happens.
       for (let b = 0; b < 256; b++) {
-        data.puzzleSolverInput[123] = b;
-        const [s, hash] = solve(data.puzzleSolverInput, data.threshold);
+        input[123] = b;
+        const [s, hash] = solve(input, data.threshold);
         if (hash.length === 0) {
           // This means 2^32 puzzles were evaluated, which takes a while in a browser!
           // As we try 256 times, this is not fatal
@@ -96,9 +98,9 @@ self.onmessage = async (evt: any) => {
 
       self.postMessage({
         type: "done",
+        puzzleSolverInput: data.puzzleSolverInput,
         solution: solution.slice(-8), // The last 8 bytes are the solution nonce
         h: totalH,
-        puzzleIndex: data.puzzleIndex,
       } as DonePartMessage);
     }
   } catch (e) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -99,6 +99,7 @@ self.onmessage = async (evt: any) => {
         solution: solution.slice(-8), // The last 8 bytes are the solution nonce
         h: totalH,
         puzzleIndex: data.puzzleIndex,
+        puzzleNumber: data.puzzleNumber,
       } as DonePartMessage);
     }
   } catch (e) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3,7 +3,7 @@ import { base64 } from "friendly-pow/wasm/optimized.wrap";
 import { getWasmSolver } from "friendly-pow/api/wasm";
 import { getJSSolver } from "friendly-pow/api/js";
 import { SOLVER_TYPE_JS, SOLVER_TYPE_WASM } from "friendly-pow/constants";
-import { Solver, DonePartMessage, ProgressPartMessage, MessageToWorker } from "./types";
+import { Solver, DonePartMessage, MessageToWorker } from "./types";
 
 if (!Uint8Array.prototype.slice) {
   Object.defineProperty(Uint8Array.prototype, "slice", {
@@ -26,7 +26,6 @@ let solverType: 1 | 2;
 // Puzzle consisting of zeroes
 let setSolver: (s: Solver) => void;
 const solver: Promise<Solver> = new Promise((resolve) => (setSolver = resolve));
-let hasStarted = false;
 
 self.onerror = (evt: any) => {
   self.postMessage({
@@ -67,10 +66,6 @@ self.onmessage = async (evt: any) => {
         solver: solverType,
       });
     } else if (data.type === "start") {
-      if (hasStarted) {
-        return;
-      }
-      hasStarted = true;
       const solve = await solver;
 
       self.postMessage({
@@ -78,48 +73,33 @@ self.onmessage = async (evt: any) => {
       });
 
       let totalH = 0;
-      const starts = data.puzzleSolverInputs;
-      const solutionBuffer = new Uint8Array(8 * data.n);
+      let solution!: Uint8Array;
 
-      // In the case of 4 workers, the first worker will solve puzzle
-      // 0, 4, 8, 12 etc
-      for (let puzNum = data.startIndex; puzNum < starts.length; puzNum += data.numWorkers) {
-        let solution!: Uint8Array;
-
-        // We loop over a uint32 to find as solution, it is technically possible (but extremely unlikely - only possible with very high difficulty) that
-        // there is no solution, here we loop over one byte further up too in case that happens.
-        for (let b = 0; b < 256; b++) {
-          starts[puzNum][123] = b;
-          const [s, hash] = solve(starts[puzNum], data.threshold);
-          if (hash.length === 0) {
-            // This means 2^32 puzzles were evaluated, which takes a while in a browser!
-            // As we try 256 times, this is not fatal
-            console.warn("FC: Internal error or no solution found");
-            totalH += Math.pow(2, 32) - 1;
-            continue;
-          }
-          solution = s;
-          break;
+      // We loop over a uint32 to find as solution, it is technically possible (but extremely unlikely - only possible with very high difficulty) that
+      // there is no solution, here we loop over one byte further up too in case that happens.
+      for (let b = 0; b < 256; b++) {
+        data.puzzleSolverInput[123] = b;
+        const [s, hash] = solve(data.puzzleSolverInput, data.threshold);
+        if (hash.length === 0) {
+          // This means 2^32 puzzles were evaluated, which takes a while in a browser!
+          // As we try 256 times, this is not fatal
+          console.warn("FC: Internal error or no solution found");
+          totalH += Math.pow(2, 32) - 1;
+          continue;
         }
-        const view = new DataView(solution.slice(-4).buffer);
-        const h = view.getUint32(0, true);
-        totalH += h;
-
-        solutionBuffer.set(solution.slice(-8), puzNum * 8); // The last 8 bytes are the solution nonce
-        self.postMessage({
-          type: "progress",
-          h: h,
-        } as ProgressPartMessage);
+        solution = s;
+        break;
       }
 
-      const doneMessage: DonePartMessage = {
-        type: "done",
-        solution: solutionBuffer,
-        totalH: totalH,
-        startIndex: data.startIndex,
-      };
+      const view = new DataView(solution.slice(-4).buffer);
+      totalH += view.getUint32(0, true);
 
-      self.postMessage(doneMessage);
+      self.postMessage({
+        type: "done",
+        solution: solution.slice(-8), // The last 8 bytes are the solution nonce
+        h: totalH,
+        puzIndex: data.puzIndex,
+      } as DonePartMessage);
     }
   } catch (e) {
     setTimeout(() => {

--- a/src/workergroup.ts
+++ b/src/workergroup.ts
@@ -36,11 +36,7 @@ export class WorkerGroup {
   public errorCallback: (e: any) => any = () => 0;
 
   public init() {
-    if (this.workers.length > 0) {
-      for (let i = 0; i < this.workers.length; i++) {
-        this.workers[i].terminate();
-      }
-    }
+    this.terminateWorkers();
 
     this.progress = 0;
     this.totalHashes = 0;

--- a/src/workergroup.ts
+++ b/src/workergroup.ts
@@ -1,7 +1,7 @@
 import { Puzzle } from "./puzzle";
 import { getPuzzleSolverInputs } from "friendly-pow/puzzle";
 import { createDiagnosticsBuffer } from "friendly-pow/diagnostics";
-import { DoneMessage, ProgressMessage, MessageFromWorker, SolverMessage } from "./types";
+import { DoneMessage, ProgressMessage, MessageFromWorker, SolverMessage, StartMessage } from "./types";
 // @ts-ignore
 import workerString from "../dist/worker.min.js";
 
@@ -12,20 +12,21 @@ if (typeof window !== "undefined") {
 }
 
 export class WorkerGroup {
-
   private workers: Worker[] = [];
+  // workers that are ready to solve a puzzle
+  private readyWorkers: Worker[] = [];
+
   private numPuzzles = 0;
   private startTime = 0;
   private progress = 0;
   private totalHashes = 0;
-  private puzzleSolverInputs: Uint8Array[] = [];
   private solutionBuffer: Uint8Array = new Uint8Array(0);
   // initialize some value, so ts is happy
   private solverType: 1 | 2 = 1;
 
-  private readyCount = 0;
   private startCount = 0;
-  private doneCount = 0;
+
+  private resolveNextReady: () => any = () => 0;
 
   public progressCallback: (p: ProgressMessage) => any = () => 0;
   public readyCallback: () => any = () => 0;
@@ -35,43 +36,37 @@ export class WorkerGroup {
 
   public init() {
     if (this.workers.length > 0) {
-      for (let i=0; i < this.workers.length; i++) {
+      for (let i = 0; i < this.workers.length; i++) {
         this.workers[i].terminate();
       }
     }
 
     this.progress = 0;
     this.totalHashes = 0;
-    
-    this.readyCount = 0;
+
     this.startCount = 0;
-    this.doneCount = 0;
 
     // Setup four workers for now - later we could calculate this depending on the device
     this.workers = new Array(4);
+    this.readyWorkers = [];
     const workerBlob = new Blob([workerString] as any, { type: "text/javascript" });
 
-    for (let i=0; i<this.workers.length; i++) {
+    for (let i = 0; i < this.workers.length; i++) {
       this.workers[i] = new Worker(URL.createObjectURL(workerBlob));
       this.workers[i].onerror = (e: ErrorEvent) => this.errorCallback(e);
 
       this.workers[i].onmessage = (e: any) => {
         const data: MessageFromWorker = e.data;
         if (!data) return;
-        if (data.type === "progress") {
-          this.progress++;
-          this.totalHashes += data.h;
-          this.progressCallback({
-            n: this.numPuzzles,
-            h: this.totalHashes,
-            t: (Date.now() - this.startTime) / 1000,
-            i: this.progress,
-          });
-        } else if (data.type === "ready") {
-          this.readyCount++;
+        if (data.type === "ready") {
+          if (!this.readyWorkers.includes(this.workers[i])) {
+            this.readyWorkers.push(this.workers[i]);
+            this.resolveNextReady();
+          }
+
           this.solverType = data.solver;
           // We are ready, when all workers are ready
-          if (this.readyCount == this.workers.length) {
+          if (this.readyWorkers.length == this.workers.length) {
             this.readyCallback();
           }
         } else if (data.type === "started") {
@@ -82,19 +77,29 @@ export class WorkerGroup {
             this.startedCallback();
           }
         } else if (data.type === "done") {
-          this.doneCount++;
-          for (let i=data.startIndex; i<this.puzzleSolverInputs.length; i+=this.workers.length) {
-            this.solutionBuffer.set(data.solution.subarray(i*8, i*8+8), i*8);
-          }
-          // We are done, when all workers are done
-          if (this.doneCount == this.workers.length) {
+          this.readyWorkers.push(this.workers[i]);
+          this.resolveNextReady();
+
+          this.progress++;
+          this.totalHashes += data.h;
+
+          this.progressCallback({
+            n: this.numPuzzles,
+            h: this.totalHashes,
+            t: (Date.now() - this.startTime) / 1000,
+            i: this.progress,
+          });
+
+          this.solutionBuffer.set(data.solution, data.puzIndex * 8);
+          // We are done, when all puzzles have been solved
+          if (this.progress == this.numPuzzles) {
             const totalTime = (Date.now() - this.startTime) / 1000;
             this.doneCallback({
               solution: this.solutionBuffer,
               h: this.totalHashes,
               t: totalTime,
               diagnostics: createDiagnosticsBuffer(this.solverType, totalTime),
-              solver: this.solverType
+              solver: this.solverType,
             });
           }
         } else if (data.type === "error") {
@@ -106,34 +111,39 @@ export class WorkerGroup {
 
   public setupSolver(forceJS = false) {
     const msg: SolverMessage = { type: "solver", forceJS: forceJS };
-    for (let i=0; i<this.workers.length; i++) {
+    for (let i = 0; i < this.workers.length; i++) {
       this.workers[i].postMessage(msg);
     }
   }
 
-  public start(puzzle: Puzzle) {
-    this.puzzleSolverInputs = getPuzzleSolverInputs(puzzle.buffer, puzzle.n);
+  private async getReadyWorker(): Promise<Worker> {
+    while (!this.readyWorkers.length) {
+      await new Promise<void>((resolve) => (this.resolveNextReady = resolve));
+    }
+    return this.readyWorkers.pop()!;
+  }
+
+  public async start(puzzle: Puzzle) {
+    const puzzleSolverInputs = getPuzzleSolverInputs(puzzle.buffer, puzzle.n);
     this.solutionBuffer = new Uint8Array(8 * puzzle.n);
     this.numPuzzles = puzzle.n;
 
-    for (let i=0; i<this.workers.length; i++) {
-      this.workers[i].postMessage({
+    for (let puzIndex = 0; puzIndex < puzzleSolverInputs.length; puzIndex++) {
+      const worker = await this.getReadyWorker();
+      worker.postMessage({
         type: "start",
-        puzzleSolverInputs: this.puzzleSolverInputs,
+        puzzleSolverInput: puzzleSolverInputs[puzIndex],
         threshold: puzzle.threshold,
-        n: puzzle.n,
-        numWorkers: this.workers.length,
-        startIndex: i,
-      });
+        puzIndex,
+      } as StartMessage);
     }
   }
 
   public terminateWorkers() {
     if (this.workers.length == 0) return;
-    for (let i=0; i<this.workers.length; i++) {
+    for (let i = 0; i < this.workers.length; i++) {
       this.workers[i].terminate();
     }
     this.workers = [];
   }
-
 }

--- a/src/workergroup.ts
+++ b/src/workergroup.ts
@@ -70,9 +70,6 @@ export class WorkerGroup {
             this.startedCallback();
           }
         } else if (data.type === "done") {
-          const puzzleIndex = this.puzzleSolverInputs.indexOf(data.puzzleSolverInput);
-          if (puzzleIndex === -1) return; // the solution belongs to a different puzzle (should usually not happen)
-
           if (this.puzzleIndex < this.puzzleSolverInputs.length) {
             this.workers[i].postMessage({
               type: "start",
@@ -93,8 +90,7 @@ export class WorkerGroup {
             i: this.progress,
           });
 
-          this.solutionBuffer.set(data.solution, puzzleIndex * 8);
-
+          this.solutionBuffer.set(data.solution, data.puzzleIndex * 8);
           // We are done, when all puzzles have been solved
           if (this.progress == this.numPuzzles) {
             const totalTime = (Date.now() - this.startTime) / 1000;
@@ -134,6 +130,7 @@ export class WorkerGroup {
         type: "start",
         puzzleSolverInput: this.puzzleSolverInputs[i],
         threshold: this.threshold,
+        puzzleIndex: this.puzzleIndex,
       } as StartMessage);
       this.puzzleIndex++;
     }

--- a/src/workergroup.ts
+++ b/src/workergroup.ts
@@ -14,6 +14,8 @@ if (typeof window !== "undefined") {
 export class WorkerGroup {
   private workers: Worker[] = [];
 
+  private puzzleNumber = 0;
+
   private numPuzzles = 0;
   private threshold = 0;
   private startTime = 0;
@@ -70,12 +72,15 @@ export class WorkerGroup {
             this.startedCallback();
           }
         } else if (data.type === "done") {
+          if (data.puzzleNumber !== this.puzzleNumber) return; // solution belongs to a previous puzzle
+
           if (this.puzzleIndex < this.puzzleSolverInputs.length) {
             this.workers[i].postMessage({
               type: "start",
               puzzleSolverInput: this.puzzleSolverInputs[this.puzzleIndex],
               threshold: this.threshold,
               puzzleIndex: this.puzzleIndex,
+              puzzleNumber: this.puzzleNumber,
             } as StartMessage);
             this.puzzleIndex++;
           }
@@ -122,6 +127,7 @@ export class WorkerGroup {
     this.numPuzzles = puzzle.n;
     this.threshold = puzzle.threshold;
     this.puzzleIndex = 0;
+    this.puzzleNumber++;
 
     for (let i = 0; i < this.workers.length; i++) {
       if (this.puzzleIndex === this.puzzleSolverInputs.length) break;
@@ -131,6 +137,7 @@ export class WorkerGroup {
         puzzleSolverInput: this.puzzleSolverInputs[i],
         threshold: this.threshold,
         puzzleIndex: this.puzzleIndex,
+        puzzleNumber: this.puzzleNumber,
       } as StartMessage);
       this.puzzleIndex++;
     }

--- a/src/workergroup.ts
+++ b/src/workergroup.ts
@@ -70,6 +70,9 @@ export class WorkerGroup {
             this.startedCallback();
           }
         } else if (data.type === "done") {
+          const puzzleIndex = this.puzzleSolverInputs.indexOf(data.puzzleSolverInput);
+          if (puzzleIndex === -1) return; // the solution belongs to a different puzzle (should usually not happen)
+
           if (this.puzzleIndex < this.puzzleSolverInputs.length) {
             this.workers[i].postMessage({
               type: "start",
@@ -90,7 +93,8 @@ export class WorkerGroup {
             i: this.progress,
           });
 
-          this.solutionBuffer.set(data.solution, data.puzzleIndex * 8);
+          this.solutionBuffer.set(data.solution, puzzleIndex * 8);
+
           // We are done, when all puzzles have been solved
           if (this.progress == this.numPuzzles) {
             const totalTime = (Date.now() - this.startTime) / 1000;
@@ -130,7 +134,6 @@ export class WorkerGroup {
         type: "start",
         puzzleSolverInput: this.puzzleSolverInputs[i],
         threshold: this.threshold,
-        puzzleIndex: this.puzzleIndex,
       } as StartMessage);
       this.puzzleIndex++;
     }


### PR DESCRIPTION
This PR improves the multithreading approach introduced in #63 by balancing the load more evenly between the worker threads. Instead of making each worker responsible for solving a fixed number of puzzles, each worker only receives a single puzzle at the a time and receives a new one as soon as it's done with the last one. This way the solving process is no longer (or at least less) bottlenecked by the slowest worker.
Depending on the difficulty of the puzzle this leads to speed gains of around 10-20% and should reduce the variance between "lucky" and "unlucky" solving attempts. It still produces the same exact same solution as the old implementation.

Internal Changes:
- Added an array to the workergroup which contains the workers that are ready to solve a puzzle (this also replaces `readyCount`)
- Added a function to workergrup that is used to resolve a promise when the next worker is ready
- Removed the `ProgressPartMessage` because it's now equivalent to the `DonePartMessage` message
- Removed the `doneCount` on the workergroup because it's now equivalent to `progress`
- The `start` method on the workergroup is now async and waits for workers to be ready to schedule all the puzzles