### PR TITLE
#85 Replaced fixed width style with min-width and max-width

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -17,7 +17,8 @@
 
 .frc-captcha {
     position: relative;
-    width: 312px;
+    min-width: 250px;
+    max-width: 312px;
     border: 1px solid #f4f4f4;
     padding-bottom: 12px;
     background-color: #fff;


### PR DESCRIPTION
This change prevents that captcha widgets extend beyond their container on small screens, while the same width as before is used on large screens.

I tested it with IE11, Firefox 97.0.1 (64-Bit) and Chrome 98.0.4758.102 for the widgets given in the index.html file.
250px seems to be a good min-width (at least for the default samples in index.html).
However, the texts are anyways scrollable in case custom texts or longer texts are used.

I kept the original width as max-width to keep the width as-is for large-screens.
However, a larger max-width could be used instead, if you want to support longer custom texts.

As for browser support: min and max-width should be supported starting with IE7. See
https://caniuse.com/minmaxwh for more details.

Feel free to perform further testing before merging my changes.