### PR TITLE
Fix multi-start bugs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug which allowed for starting the same widget more than once
+
 ## 0.9.1
 
 - Added Swedish (`"sv"`) and Russian (`"ru"`) localization (thank you @astonsson and @YerzhanU!).

--- a/docs/widget_api.md
+++ b/docs/widget_api.md
@@ -160,7 +160,7 @@ const FriendlyCaptcha = () => {
     }
 
     return () => {
-      if (widget.current != undefined) widget.current.reset();
+      if (widget.current != undefined) widget.current.destroy();
     }
   }, [container]);
 

--- a/docs/widget_api.md
+++ b/docs/widget_api.md
@@ -199,10 +199,10 @@ const errorCallback = (err) => {
 watch(container, () => {
   // reset the widget instance when the container changes
   if (widget.value) {
-    widget.value.reset();
+    widget.value.destroy();
   }
 
-  if (!widget.value && container.value) {
+  if (container.value) {
     widget.value = new WidgetInstance(container.value, {
       startMode: "auto",
       doneCallback: doneCallback,

--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -123,11 +123,7 @@ export class WidgetInstance {
     ) {
       const form = findParentFormElement(this.e);
       if (form) {
-        executeOnceOnFocusInEvent(form, () => {
-          if (!this.hasBeenStarted) {
-            this.start();
-          }
-        });
+        executeOnceOnFocusInEvent(form, () => this.start());
       } else {
         console.log("FriendlyCaptcha div seems not to be contained in a form, autostart will not work");
       }
@@ -191,6 +187,11 @@ export class WidgetInstance {
   public async start() {
     if (this.hasBeenDestroyed) {
       console.error("Can not start FriendlyCaptcha widget which has been destroyed");
+      return;
+    }
+
+    if (this.hasBeenStarted) {
+      console.error("Can not start FriendlyCaptcha widget which has already been started");
       return;
     }
 


### PR DESCRIPTION
With this PR it's no longer possible to start the same widget instance twice. This has been a problem when using `startMode: auto` or `startMode: focus` in combination with calling the `widget.start()` function manually. Mentioned in https://github.com/FriendlyCaptcha/friendly-challenge/issues/89#issuecomment-1057098154.

I have also updated the react and vue examples to use `widget.destroy()` instead of `widget.reset()` to cleanup the widget instance. I have described why this is necessary in https://github.com/FriendlyCaptcha/friendly-challenge/issues/89#issuecomment-1062932635.