### PR TITLE
add module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "license": "MIT",
   "repository": "https://github.com/FriendlyCaptcha/friendly-challenge",
+  "type": "module",
   "scripts": {
     "prebuild": "rimraf dist",
     "lint": "eslint src/**/*.ts test/**/*.ts",


### PR DESCRIPTION
This would allow us a direct inclusion of FriendlyCaptcha into a next.js project, which currently is not posible, due to next not knowing what type of module FC is exporting