### PR TITLE
reset `hasBeenStarted` on puzzle get error

### DIFF
--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -142,6 +142,7 @@ export class WidgetInstance {
   }
 
   private onWorkerError(e: any) {
+    this.hasBeenStarted = false;
     this.needsReInit = true;
     this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, "Background worker error " + e.message);
     this.makeButtonStart();
@@ -195,7 +196,6 @@ export class WidgetInstance {
       return;
     }
 
-    this.hasBeenStarted = true;
     const sitekey = this.opts.sitekey || this.e.dataset["sitekey"];
     if (!sitekey) {
       console.error("FriendlyCaptcha: sitekey not set on frc-captcha element");
@@ -224,6 +224,8 @@ export class WidgetInstance {
       this.init(true);
       return;
     }
+
+    this.hasBeenStarted = true;
 
     try {
       this.e.innerHTML = getFetchingHTML(this.opts.solutionFieldName, this.lang);

--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -230,6 +230,7 @@ export class WidgetInstance {
       this.puzzle = decodeBase64Puzzle(await getPuzzle(this.opts.puzzleEndpoint, sitekey, this.lang));
       setTimeout(() => this.expire(), this.puzzle.expiry - 30000); // 30s grace
     } catch (e: any) {
+      this.hasBeenStarted = false;
       this.e.innerHTML = getErrorHTML(this.opts.solutionFieldName, this.lang, e.message);
       this.makeButtonStart();
       const code = "error_getting_puzzle";


### PR DESCRIPTION
In #90 I moved the `hasBeenStarted` check from the `init` to the `start` method without considering that the retry button is also calling `start`. This made the retry button unusable in basically all cases. 

To fix this I have moved setting `hasBeenStarted` after the initial checks and also reset `hasBeenStarted` in the two other places where the retry button is rendered. Actually calling `reset` shouldn't be necessary here, I'm just setting `hasBeenStarted` back to false.

As far as I can tell this fixes the issue for all start modes and for all cases where the retry button is rendered.

fixes #108 