### PR TITLE
Reset `hasBeenStarted` in `expire()` method

### DIFF
--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -181,6 +181,7 @@ export class WidgetInstance {
   }
 
   private expire() {
+    this.hasBeenStarted = false;
     this.e.innerHTML = getExpiredHTML(this.opts.solutionFieldName, this.lang);
     this.makeButtonStart();
   }


### PR DESCRIPTION
follow up to https://github.com/FriendlyCaptcha/friendly-challenge/pull/112

Fixes regression bug where `hasBeenStarted` is not reset to `false` upon puzzle expiration.

fixes https://github.com/FriendlyCaptcha/friendly-challenge/issues/113