### PR TITLE
Return raw error in error callback

### DIFF
--- a/src/puzzle.ts
+++ b/src/puzzle.ts
@@ -55,8 +55,10 @@ export async function getPuzzle(urlsSeparatedByComma: string, siteKey: string, l
         }
       }
     } catch (e) {
-      console.error("[FriendlyCaptcha]:", e);
-      throw Error(`${lang.text_fetch_error} <a class="frc-err-url" href="${urls[i]}">${urls[i]}</a>`);
+      console.error("[FRC Fetch]:", e);
+      const err = new Error(`${lang.text_fetch_error} <a class="frc-err-url" href="${urls[i]}">${urls[i]}</a>`);
+      (err as any).rawError = e;
+      throw err;
     }
   }
   // This code should never be reached.


### PR DESCRIPTION
When an error occurs in fetching or parsing the puzzle response body it was not really possible to introspect the error programmatically without ugly hacks. This adds the raw error under a new `.rawError` field.

In the past update we added a bit more error logging (some `console.error` when an error is thrown), along with this it should be easier to debug issues.