### PR TITLE
Fix react example

### DIFF
--- a/docs/widget_api.md
+++ b/docs/widget_api.md
@@ -161,7 +161,7 @@ const FriendlyCaptcha = () => {
     }
 
     return () => {
-      if (widget.current != undefined) widget.current.destroy();
+      if (widget.current != undefined) widget.current.reset();
     }
   }, [container]);
 


### PR DESCRIPTION
Calling `widget.destroy` in the `useEffect` cleanup causes issues with React 18 strict mode. In dev mode each component is unmounted and mounted twice to enforce best-practices. When `widget.destroy` is called the element is removed from the DOM which makes it impossible to render a new widget when the component mounts again.
#145