### PR TITLE
Fix OpenAPI urls

### DIFF
--- a/docs/openapi_spec.md
+++ b/docs/openapi_spec.md
@@ -1,5 +1,5 @@
 # OpenAPI Specification
 
 For advanced usage of our public API, please refer to our OpenAPI spec:
-- [v2](./swagger.json)
-- [v3](./openapiv3.json)
+- [v2](/swagger.json)
+- [v3](/openapiv3.json)


### PR DESCRIPTION
Depending on how docsify translates the markdown this might still not work, but we'll see :) 