### PR TITLE
Update index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { WidgetInstance } from "./captcha";
 export type { WidgetInstanceOptions } from "./captcha";
-export type { Localization, localizations } from "./localization";
+export { localizations } from "./localization";
+export type { Localization } from "./localization";


### PR DESCRIPTION
Currently the constant localizations is exported as a type and is erased from the generated index.js in the npm package. For this reason we are not able to use the constant in our angular applications.