### PR TITLE
Fix Chinese (Traditional)

### DIFF
--- a/src/localization.ts
+++ b/src/localization.ts
@@ -734,7 +734,7 @@ export const localizations = {
   hu: LANG_HU,
   ro: LANG_RO,
   zh: LANG_ZH,
-  zh_TW: LANG_ZH_TW,
+  zh_tw: LANG_ZH_TW,
   vi: LANG_VI,
 
   // alternative language codes


### PR DESCRIPTION
Traditional Chinese language uses `zh_TW` key but `WidgetInstance` normalizes languages to lowercase here:

https://github.com/FriendlyCaptcha/friendly-challenge/blob/ef9d0f53df4788d7452d7b247ae5a4af48471d17/src/captcha.ts#L98
So the language is never found.

This changes the key to lowercase. I'm not sure if some B/C needs to be maintained here. If so, a new key should be added instead of old one being renamed.