### PR TITLE
Remove plugins prototype check, prepare version 0.9.10

### DIFF
--- a/docs/browser_support.md
+++ b/docs/browser_support.md
@@ -10,19 +10,19 @@ You can use the build that includes the polyfills:
 
 ```html
 <!-- from unpkg -->
-<script type="module" src="https://unpkg.com/friendly-challenge@0.9.9/widget.module.min.js" async defer></script>
-<script nomodule src="https://unpkg.com/friendly-challenge@0.9.9/widget.polyfilled.min.js" async defer></script>
+<script type="module" src="https://unpkg.com/friendly-challenge@0.9.10/widget.module.min.js" async defer></script>
+<script nomodule src="https://unpkg.com/friendly-challenge@0.9.10/widget.polyfilled.min.js" async defer></script>
 
 <!-- OR from jsdelivr -->
 <script
   type="module"
-  src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/dist/widget.module.min.js"
+  src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.10/dist/widget.module.min.js"
   async
   defer
 ></script>
 <script
   nomodule
-  src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/dist/widget.polyfilled.min.js"
+  src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.10/dist/widget.polyfilled.min.js"
   async
   defer
 ></script>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.9.10
+- Fix for false positive headless browser check in rare cases on Windows devices (`"Browser check failed, try a different browser"`).
+- Improved French (`"fr"`) localization (thank you @mikejpr!).
+
 ## 0.9.9
 - Fix for NextJS 13 production builds.
 - Added Chinese (Traditional) (`"zh_TW"`) localization (thank you @jhihyulin!).

--- a/docs/flutter.md
+++ b/docs/flutter.md
@@ -37,8 +37,8 @@ String buildPageContent({String sitekey, String theme = "", String start = "auto
     <meta charset="utf-8">
     <title>Friendly Captcha Verification</title>
 
-    <script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/widget.module.min.js"></script>
-    <script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/widget.min.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.10/widget.module.min.js"></script>
+    <script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.10/widget.min.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
         html, body {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,20 +26,20 @@ The **friendly-challenge** library contains the code for CAPTCHA widget. You hav
 
 ```html
 <!-- from unpkg -->
-<script type="module" src="https://unpkg.com/friendly-challenge@0.9.9/widget.module.min.js" async defer></script>
-<script nomodule src="https://unpkg.com/friendly-challenge@0.9.9/widget.min.js" async defer></script>
+<script type="module" src="https://unpkg.com/friendly-challenge@0.9.10/widget.module.min.js" async defer></script>
+<script nomodule src="https://unpkg.com/friendly-challenge@0.9.10/widget.min.js" async defer></script>
 
 <!-- OR from jsdelivr -->
 <script
   type="module"
-  src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/widget.module.min.js"
+  src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.10/widget.module.min.js"
   async
   defer
 ></script>
-<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/widget.min.js" async defer></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.10/widget.min.js" async defer></script>
 ```
 
-> Make sure to always import a specific version (e.g. `friendly-challenge@0.9.9`), then you can be sure that the script you import and integrate with your website doesn't change unexpectedly.
+> Make sure to always import a specific version (e.g. `friendly-challenge@0.9.10`), then you can be sure that the script you import and integrate with your website doesn't change unexpectedly.
 
 It is recommended that you include the `async` and `defer` attributes like in the examples above, they make sure that the browser does not wait to load these scripts to show your website. The size of the scripts is 18KB (8.5KB compressed) for modern browsers, and 24KB (10KB compressed) for old browsers.
 

--- a/docs/legacy_endpoint.md
+++ b/docs/legacy_endpoint.md
@@ -24,7 +24,7 @@ Please perform the following updates. Upgrading should only take a few minutes, 
 
 ### Widget and the `friendly-challenge` library
 
-If you are using version `0.8.3` or below, please update to the latest version as soon as possible. If you are using a more recent version then still we would advise to upgrade to the latest version (`0.9.9`).
+If you are using version `0.8.3` or below, please update to the latest version as soon as possible. If you are using a more recent version then still we would advise to upgrade to the latest version (`0.9.10`).
 
 The changelog can be found [here](https://github.com/FriendlyCaptcha/friendly-challenge/blob/master/docs/changelog.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "friendly-challenge",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "friendly-challenge",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friendly-challenge",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "The client code used for FriendlyCaptcha (widget script, html, styling and webworker solvers)",
   "keywords": [
     "captcha",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,4 +1,4 @@
-// Defensive init to make it easier to integrate with Gatsby and friends.
+// Defensive init to make it easier to integrate with Gatsby, NextJS, and friends.
 let nav: Navigator;
 let ua: string;
 if (typeof navigator !== "undefined") {
@@ -12,15 +12,6 @@ if (typeof navigator !== "undefined") {
  * it stops unsophisticated scripters from making any request whatsoever.
  */
 export function isHeadless() {
-  let correctPluginPrototype = true;
-  try {
-    if (nav.plugins.length > 0) {
-      correctPluginPrototype = Plugin.prototype === (nav.plugins as any)[0].__proto__;
-    }
-  } catch (e) {
-    /* Do nothing, this browser misbehaves in mysterious ways */
-  }
-
   return (
     //tell-tale bot signs
     ua.indexOf("headless") !== -1 ||
@@ -29,7 +20,6 @@ export function isHeadless() {
     ua.indexOf("crawl") !== -1 || // Only IE5 has two distributions that has this on windows NT.. so yeah.
     nav.webdriver === true ||
     !nav.language ||
-    (nav.languages !== undefined && !nav.languages.length) || // IE 11 does not support NavigatorLanguage.languages https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages
-    !correctPluginPrototype
+    (nav.languages !== undefined && !nav.languages.length) // IE 11 does not support NavigatorLanguage.languages https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages
   );
 }

--- a/src/puzzle.ts
+++ b/src/puzzle.ts
@@ -32,7 +32,7 @@ export async function getPuzzle(urlsSeparatedByComma: string, siteKey: string, l
     try {
       const response = await fetchAndRetryWithBackoff(
         urls[i] + "?sitekey=" + siteKey,
-        { headers: [["x-frc-client", "js-0.9.9"]], mode: "cors" },
+        { headers: [["x-frc-client", "js-0.9.10"]], mode: "cors" },
         2
       );
       if (response.ok) {


### PR DESCRIPTION
In some rare cases (less than one in a million?) the `navigator.plugins` prototype check would flag real users' browsers as headless. This release removes that check.