### PR TITLE
Feature: Add option that allows for removing hidden form field entirely

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 - Improvement to the French (`"fr"`) localization.
+- Added feature for not including the hidden form field at all.
 
 ### 0.9.12
 - No longer uses the title attribute for debug information during solving. Some screen readers would read this title as it updates.

--- a/docs/widget_api.md
+++ b/docs/widget_api.md
@@ -55,6 +55,8 @@ Example:
 <div class="frc-captcha" data-sitekey="<my sitekey>" data-solution-field-name="my-captcha-solution-field"></div>
 ```
 
+You can completely omit this hidden form field by setting this value to `"-"`.
+
 ### data-puzzle-endpoint
 *Only relevant if you are using our [dedicated EU endpoint service](/#/eu_endpoint)*.
 By default the widget fetches puzzles from `https://api.friendlycaptcha.com/api/v1/puzzle`, which serves puzzles globally from over 200 data centers. As a premium service we offer an alternative endpoint that serves requests from datacenters in Germany only.
@@ -114,7 +116,7 @@ The options object takes the following fields, they are all optional:
 * **`doneCallback`**: function, called when the CAPTCHA has been completed. One argument will be passed: the solution string that should be sent to the server.
 * **`errorCallback`**: function, called when an internal error occurs. The error is passed as an object, the fields and values of this object are still to be documented may change in the future. Consider this experimental. In case of a fetch error (e.g. network connection loss or firewall block), the raw error of the fetch request can be retrieved under the `error.rawError` member variable.
 * **`language`**: string or object, the same values as the `data-lang` attribute can be provided, or a custom translation object for your language. See [here](https://github.com/FriendlyCaptcha/friendly-challenge/blob/master/src/localization.ts) for what this object should look like.
-* **`solutionFieldName`**: string, default `"frc-captcha-solution"`. The solution to the CAPTCHA will be put in a hidden form field with this name.
+* **`solutionFieldName`**: string, default `"frc-captcha-solution"`. The solution to the CAPTCHA will be put in a hidden form field with this name. If you set this value to `"-"`, no hidden form field is injected at all.
 
 * **`puzzleEndpoint`**: string, the URL the widget should retrieve its puzzle from. This defaults to Friendly Captcha's endpoint, you will only ever need to change this if you are creating your own puzzles or are using our dedicated EU endpoint service.
 * **`skipStyleInjection`**: boolean, if this is set to true the Friendly Captcha widget CSS will no longer be automatically injected into your webpage. You will be responsible for styling the element yourself.

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -32,7 +32,7 @@ function getTemplate(
     ${progress ? `<progress class="frc-progress" value="0">0%</progress>` : ""}
 </div>
 </div><span class="frc-banner"><a lang="en" href="https://friendlycaptcha.com/" rel="noopener" target="_blank"><b>Friendly</b>Captcha ⇗</a></span>
-<input name="${fieldName}" class="frc-captcha-solution" type="hidden" value="${solutionString}">`;
+${fieldName === "-" ? "":`<input name="${fieldName}" class="frc-captcha-solution" type="hidden" value="${solutionString}">`}`;
 }
 
 /**

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -21,6 +21,9 @@
     <h3>Custom field name</h3>
     <div class="frc-captcha" data-sitekey="FCMGEMUD2KTDSQ5H" data-solution-field-name="my-field-name"></div>
 
+    <h3>No hidden form field</h3>
+    <div class="frc-captcha" data-sitekey="FCMGEMUD2KTDSQ5H" data-solution-field-name="-"></div>
+
     <h3>Invalid sitekey</h3>
     <div class="frc-captcha" data-sitekey="FCMGEMUD2KTDSABC"></div>
 


### PR DESCRIPTION
You can now pass `"-"` for the `solution-field-name`/`solutionFieldName` option, then no hidden form field will be present whatsoever. Related to #216 