### PR TITLE
Fix missing changelog items in sidebar

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,21 +1,21 @@
 # Changelog
 
-### Unreleased
+## Unreleased
 - Small tweak to the French (`"fr"`) localization.
 
-### 0.9.13
+## 0.9.13
 - Improvement to the French (`"fr"`) localization.
 - Added feature for not including the hidden form field at all by passing `"-"` as custom field name.
 
-### 0.9.12
+## 0.9.12
 - No longer uses the title attribute for debug information during solving. Some screen readers would read this title as it updates.
 - Localization fix for Vietnamese (`"vi"`).
 - The widget now exposes a `loadLanguage` function that allows you to programmatically change the language of the widget.
 
-### 0.9.11
+## 0.9.11
 - Improvements to localizations, fix for Romanian (`"ro"`) localization (thank you @zcserei!).
 
-### 0.9.10
+## 0.9.10
 - Fix for false positive headless browser check in rare cases on Windows devices (`"Browser check failed, try a different browser"`).
 - Improved French (`"fr"`) localization (thank you @mikejpr!).
 


### PR DESCRIPTION
Before:
![image](https://github.com/FriendlyCaptcha/friendly-captcha/assets/39121311/97e4deeb-5399-48a2-a867-186e597493d4)

After:
![2023-10-11-145812_1654x802_scrot](https://github.com/FriendlyCaptcha/friendly-challenge/assets/1009277/5316dea2-5662-4a7b-9f9d-20315335e51e)


FYI @denagyantal (GH wouldn't allow me to set you as reviewer)