### PR TITLE
Fix event order edge case

### DIFF
--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -140,7 +140,7 @@ export class WidgetInstance {
     if (typeof this.opts.language === "string") {
       let langCode = this.opts.language.toLowerCase();
       let l = (localizations as any)[langCode];
-      if (l === undefined && langCode[2] === '-') {
+      if (l === undefined && langCode[2] === "-") {
         // Language has a locale '-' separator, remove it and try again
         langCode = langCode.substring(0, 2);
         l = (localizations as any)[langCode];
@@ -281,7 +281,7 @@ export class WidgetInstance {
       return;
     }
 
-    this.workerGroup.start(this.puzzle);
+    await this.workerGroup.start(this.puzzle);
   }
 
   /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,29 +42,31 @@ self.onmessage = async (evt: any) => {
      * If WASM support is not present, it uses the JS version instead.
      */
     if (data.type === "solver") {
+      let s: Solver;
+
       if (data.forceJS) {
         solverType = SOLVER_TYPE_JS;
-        const s = await getJSSolver();
+        s = await getJSSolver();
         setSolver(s);
       } else {
         try {
           solverType = SOLVER_TYPE_WASM;
           const module = WebAssembly.compile(decode(base64));
-          const s = await getWasmSolver(await module);
-          setSolver(s);
+          s = await getWasmSolver(await module);
         } catch (e: any) {
           console.log(
             "FriendlyCaptcha failed to initialize WebAssembly, falling back to Javascript solver: " + e.toString()
           );
           solverType = SOLVER_TYPE_JS;
-          const s = await getJSSolver();
-          setSolver(s);
+          s = await getJSSolver();
         }
       }
+
       self.postMessage({
         type: "ready",
         solver: solverType,
       });
+      setSolver(s);
     } else if (data.type === "start") {
       const solve = await solver;
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,23 +42,23 @@ self.onmessage = async (evt: any) => {
      * If WASM support is not present, it uses the JS version instead.
      */
     if (data.type === "solver") {
-      let s: Solver;
-
       if (data.forceJS) {
         solverType = SOLVER_TYPE_JS;
-        s = await getJSSolver();
+        const s = await getJSSolver();
         setSolver(s);
       } else {
         try {
           solverType = SOLVER_TYPE_WASM;
           const module = WebAssembly.compile(decode(base64));
-          s = await getWasmSolver(await module);
+          const s = await getWasmSolver(await module);
+          setSolver(s);
         } catch (e: any) {
           console.log(
             "FriendlyCaptcha failed to initialize WebAssembly, falling back to Javascript solver: " + e.toString()
           );
           solverType = SOLVER_TYPE_JS;
-          s = await getJSSolver();
+          const s = await getJSSolver();
+          setSolver(s);
         }
       }
 
@@ -66,7 +66,6 @@ self.onmessage = async (evt: any) => {
         type: "ready",
         solver: solverType,
       });
-      setSolver(s);
     } else if (data.type === "start") {
       const solve = await solver;
 


### PR DESCRIPTION
In some rare cases when the worker group is started before all workers are ready (have compiled the WASM solver), the `ready` event is emitted after the `started` event. This causes the widget UI to be stuck in the ready state until the puzzle is solved.

To fix this I have added a promise which is resolved when the whole worker group is ready. This way the `start` method waits for the `ready` event.

Another approach would be to ignore all `started` events from workers until all workers are ready. I feel like this could have some side effects tho